### PR TITLE
Clap interoperability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ clicolor = []
 clicolor_force = []
 
 [dependencies]
-clap = { version = "3.2.20", features = ["derive", "std"], default-features = false, optional = true }
+clap = { version = "3.2.20", features = ["color", "derive", "std"], default-features = false, optional = true }
 
 [dev-dependencies]
 itertools = "0.10.3"


### PR DESCRIPTION
This PR addresses #3.

Additions:

- optional dependency `clap` with features `color`, `derive`, `std`
- conversions `ColorChoice` <--> `clap::ColorChoice`
- `impl ValueEnum for ColorChoice`
- `clap_color()`